### PR TITLE
[refactor] Helmper now uses cache path from Helm environment configuration

### DIFF
--- a/internal/bootstrap/viper.go
+++ b/internal/bootstrap/viper.go
@@ -48,8 +48,9 @@ type ImportConfigSection struct {
 }
 
 type registryConfigSection struct {
-	Name string `yaml:"name"`
-	URL  string `yaml:"url"`
+	Name      string `yaml:"name"`
+	URL       string `yaml:"url"`
+	PlainHTTP bool   `yaml:"plainHTTP"`
 }
 
 type config struct {
@@ -155,8 +156,9 @@ copacetic:
 	for _, r := range regConf.Registries {
 		rs = append(rs,
 			registry.Registry{
-				Name: r.Name,
-				URL:  r.URL,
+				Name:      r.Name,
+				URL:       r.URL,
+				PlainHTTP: r.PlainHTTP,
 			})
 	}
 	state.SetValue(viper, "registries", rs)

--- a/internal/program.go
+++ b/internal/program.go
@@ -152,9 +152,10 @@ func Program(args []string) error {
 			}))
 
 		so := trivy.ScanOption{
-			DockerHost:  importConfig.Import.Copacetic.Buildkitd.Addr,
-			TrivyServer: importConfig.Import.Copacetic.Trivy.Addr,
-			Insecure:    importConfig.Import.Copacetic.Trivy.Insecure,
+			DockerHost:    importConfig.Import.Copacetic.Buildkitd.Addr,
+			TrivyServer:   importConfig.Import.Copacetic.Trivy.Addr,
+			Insecure:      importConfig.Import.Copacetic.Trivy.Insecure,
+			IgnoreUnfixed: importConfig.Import.Copacetic.Trivy.IgnoreUnfixed,
 		}
 
 		for _, i := range imgs {
@@ -234,7 +235,7 @@ func Program(args []string) error {
 			}
 		}()
 
-		// import images without os-pkgs vulnerabilities
+		// Import images without os-pkgs vulnerabilities
 		iOpts := registry.ImportOption{
 			Registries: registries,
 			Imgs:       push,
@@ -245,7 +246,7 @@ func Program(args []string) error {
 			return err
 		}
 
-		// patch image and save to tar
+		// Patch image and save to tar
 		po := copa.PatchOption{
 			Imgs:       patch,
 			Registries: registries,

--- a/pkg/helm/chartImportOption.go
+++ b/pkg/helm/chartImportOption.go
@@ -98,7 +98,7 @@ func (opt ChartImportOption) Run(ctx context.Context, setters ...Option) error {
 
 			_, err := r.Exist(ctx, "charts/"+c.Name, c.Version)
 			if err == nil {
-				slog.Info("Chart already present in registry", slog.String("chart", "charts/"+c.Name), slog.String("registry", "oci://"+r.URL))
+				slog.Info("Chart already present in registry. Skipping import", slog.String("chart", "charts/"+c.Name), slog.String("registry", "oci://"+r.URL))
 				continue
 			}
 

--- a/pkg/registry/importOption.go
+++ b/pkg/registry/importOption.go
@@ -20,7 +20,7 @@ type ImportOption struct {
 
 func (io ImportOption) Run(ctx context.Context) error {
 
-	slog.Debug("pushing missing images to registries..")
+	slog.Debug("pushing images to registries..")
 
 	bar := progressbar.NewOptions(len(io.Imgs), progressbar.OptionSetWriter(ansi.NewAnsiStdout()), // "github.com/k0kubun/go-ansi"
 		progressbar.OptionEnableColorCodes(true),


### PR DESCRIPTION
As title says, Helmper will now use the cache directory specified in Helm environment configuration (`helm env`). Solves #5 