### PR TITLE
feat: cosign password env

### DIFF
--- a/cmd/helmper/main.go
+++ b/cmd/helmper/main.go
@@ -12,5 +12,6 @@ func main() {
 	err := internal.Program(os.Args[1:])
 	if err != nil {
 		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,7 @@ require (
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
@@ -373,7 +373,7 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/cobra v1.8.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/spiffe/go-spiffe/v2 v2.2.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect

--- a/internal/bootstrap/viper.go
+++ b/internal/bootstrap/viper.go
@@ -114,7 +114,6 @@ func LoadViperConfiguration(_ []string) (*viper.Viper, error) {
 	if err := viper.Unmarshal(&conf); err != nil {
 		return nil, err
 	}
-	viper.Set("importConfig", conf)
 
 	if conf.Import.Cosign.Enabled && conf.Import.Cosign.KeyRef == "" {
 		s := `
@@ -177,6 +176,8 @@ copacetic:
 		}
 
 	}
+
+	viper.Set("importConfig", conf)
 
 	rs := []registry.Registry{}
 	for _, r := range regConf.Registries {

--- a/internal/bootstrap/viper.go
+++ b/internal/bootstrap/viper.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"log/slog"
+	"os"
 
 	"github.com/ChristofferNissen/helmper/pkg/helm"
 	"github.com/ChristofferNissen/helmper/pkg/registry"
@@ -42,11 +43,11 @@ type ImportConfigSection struct {
 			} `yaml:"output"`
 		} `yaml:"copacetic"`
 		Cosign struct {
-			Enabled           bool   `yaml:"enabled"`
-			KeyRef            string `yaml:"keyRef"`
-			KeyRefPass        string `yaml:"keyRefPass"`
-			AllowHTTPRegistry bool   `yaml:"allowHTTPRegistry"`
-			AllowInsecure     bool   `yaml:"allowInsecure"`
+			Enabled           bool    `yaml:"enabled"`
+			KeyRef            string  `yaml:"keyRef"`
+			KeyRefPass        *string `yaml:"keyRefPass"`
+			AllowHTTPRegistry bool    `yaml:"allowHTTPRegistry"`
+			AllowInsecure     bool    `yaml:"allowInsecure"`
 		} `yaml:"cosign"`
 	} `yaml:"import"`
 }
@@ -123,6 +124,12 @@ import:
     keyRef: ""     <---
 `
 		return nil, xerrors.Errorf("You have enabled cosign but did not specify any keyRef. Please specify a keyRef and try again..\nExample config:\n%s", s)
+	}
+
+	if conf.Import.Cosign.Enabled && conf.Import.Cosign.KeyRefPass == nil {
+		v := os.Getenv("COSIGN_PASSWORD")
+		slog.Info("KeyRefPass is nil, using value of COSIGN_PASSWORD environment variable")
+		conf.Import.Cosign.KeyRefPass = &v
 	}
 
 	if conf.Import.Copacetic.Enabled {

--- a/internal/program.go
+++ b/internal/program.go
@@ -321,7 +321,7 @@ func Program(args []string) error {
 				Registries: registries,
 
 				KeyRef:            importConfig.Import.Cosign.KeyRef,
-				KeyRefPass:        importConfig.Import.Cosign.KeyRefPass,
+				KeyRefPass:        *importConfig.Import.Cosign.KeyRefPass,
 				AllowInsecure:     importConfig.Import.Cosign.AllowInsecure,
 				AllowHTTPRegistry: importConfig.Import.Cosign.AllowHTTPRegistry,
 			}
@@ -352,7 +352,7 @@ func Program(args []string) error {
 				Registries: registries,
 
 				KeyRef:            importConfig.Import.Cosign.KeyRef,
-				KeyRefPass:        importConfig.Import.Cosign.KeyRefPass,
+				KeyRefPass:        *importConfig.Import.Cosign.KeyRefPass,
 				AllowInsecure:     importConfig.Import.Cosign.AllowInsecure,
 				AllowHTTPRegistry: importConfig.Import.Cosign.AllowHTTPRegistry,
 			}

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -195,3 +195,9 @@ k8s://[NAMESPACE]/[KEY]
 ```text title="Azure Key vault"
 azurekms://[VAULT_NAME][VAULT_URI]/[KEY]
 ```
+
+### keyRefPass
+
+Helmper supports specifying the password directly in the helmper.yaml as `keyRefPass`. Alternatively you can use the `COSIGN_PASSWORD` environment variable to specify the password.
+
+If you use any of the remote options for `keyRef` you can leave the keyRefPass unspecified.


### PR DESCRIPTION
Add option to use `COSIGN_PASSWORD` for specifying password to cosign.

Add exit code 1 when error occurs during execution of Helmper for displaying correct CI status.

Closes #28
Closes #29 