### PR TITLE
feat: added retry logic to cosign

### DIFF
--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ChristofferNissen/helmper/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/k0kubun/go-ansi"
 	"github.com/schollz/progressbar/v3"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
@@ -68,6 +69,15 @@ func (so SignOption) Run() error {
 		Registry: options.RegistryOptions{
 			AllowInsecure:     so.AllowInsecure,
 			AllowHTTPRegistry: so.AllowHTTPRegistry,
+			RegistryClientOpts: []remote.Option{
+				remote.WithRetryBackoff(remote.Backoff{
+					Duration: 1 * time.Second,
+					Jitter:   1.0,
+					Factor:   2.0,
+					Steps:    5,
+					Cap:      2 * time.Minute,
+				}),
+			},
 		},
 	}
 


### PR DESCRIPTION
Add retry logic to Cosign through the Cosign SDK, similarly to how we have retry for Helm operations through the Helm SDK in `pkg/helm`

Closes #30 