### PR TITLE
fix: changed timeout for cosign

### DIFF
--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -52,9 +52,9 @@ func (so SignOption) Run() error {
 		}))
 
 	// Sign with cosign
-
+	timeout := 2 * time.Minute
 	ro := options.RootOptions{
-		Timeout: 10 * time.Second,
+		Timeout: timeout,
 		Verbose: false,
 	}
 	ko := options.KeyOpts{
@@ -75,7 +75,7 @@ func (so SignOption) Run() error {
 					Jitter:   1.0,
 					Factor:   2.0,
 					Steps:    5,
-					Cap:      2 * time.Minute,
+					Cap:      timeout,
 				}),
 			},
 		},


### PR DESCRIPTION
Changed timeout for cosign sign command invocation closer to default in cosign lib to allow for more time to retry