### PR TITLE
[fix] add check on protocol used for repo.url in viper configuration

### DIFF
--- a/pkg/helm/chartCollection.go
+++ b/pkg/helm/chartCollection.go
@@ -2,8 +2,10 @@ package helm
 
 import (
 	"log"
+	"strings"
 
 	"github.com/ChristofferNissen/helmper/pkg/util/terminal"
+	"golang.org/x/xerrors"
 	"helm.sh/helm/v3/pkg/cli"
 )
 
@@ -41,6 +43,15 @@ func (collection ChartCollection) SetupHelm(setters ...Option) error {
 
 	for _, setter := range setters {
 		setter(args)
+	}
+
+	for _, c := range collection.Charts {
+		if !(strings.HasPrefix(c.Repo.URL, "http") || strings.HasPrefix(c.Repo.URL, "https")) {
+			if strings.HasPrefix(c.Repo.URL, "oci") {
+				return xerrors.New("Helm only supports 'http and 'https' protocol for Helm Repositories. For oci protocol, see docs on the chart.oci configuration option in Helmper.")
+			}
+			return xerrors.New("Helm only supports 'http and 'https' protocol for Helm Repositories")
+		}
 	}
 
 	// Add Helm Repos


### PR DESCRIPTION
Add check for protocol used to specify Helm Repository in helmper.yaml to avoid adding broken repository config to repositories.yml

Part of the fix for #40 

Closes #41 