### PR TITLE
[feat] add option to specify image architecture for import

### DIFF
--- a/example/helmper.yaml
+++ b/example/helmper.yaml
@@ -4,6 +4,7 @@ update: false
 all: false
 import:
   enabled: true
+  architecture: "linux/amd64"
   copacetic:
     enabled: true
     ignoreErrors: true

--- a/internal/bootstrap/viper.go
+++ b/internal/bootstrap/viper.go
@@ -15,9 +15,9 @@ import (
 
 type ImportConfigSection struct {
 	Import struct {
-		Enabled bool `yaml:"enabled"`
-		// all     bool `yaml:"all"`
-		Copacetic struct {
+		Enabled      bool    `yaml:"enabled"`
+		Architecture *string `yaml:"architecture"`
+		Copacetic    struct {
 			Enabled      bool `yaml:"enabled"`
 			IgnoreErrors bool `yaml:"ignoreErrors"`
 			Buildkitd    struct {

--- a/internal/program.go
+++ b/internal/program.go
@@ -156,6 +156,7 @@ func Program(args []string) error {
 			TrivyServer:   importConfig.Import.Copacetic.Trivy.Addr,
 			Insecure:      importConfig.Import.Copacetic.Trivy.Insecure,
 			IgnoreUnfixed: importConfig.Import.Copacetic.Trivy.IgnoreUnfixed,
+			Architecture:  importConfig.Import.Architecture,
 		}
 
 		for _, i := range imgs {
@@ -246,9 +247,10 @@ func Program(args []string) error {
 
 		// Import images without os-pkgs vulnerabilities
 		iOpts := registry.ImportOption{
-			Registries: registries,
-			Imgs:       push,
-			All:        all,
+			Registries:   registries,
+			Imgs:         push,
+			All:          all,
+			Architecture: importConfig.Import.Architecture,
 		}
 		err = iOpts.Run(ctx)
 		if err != nil {
@@ -271,6 +273,7 @@ func Program(args []string) error {
 				KeyPath:    importConfig.Import.Copacetic.Buildkitd.KeyPath,
 			},
 			IgnoreErrors: importConfig.Import.Copacetic.IgnoreErrors,
+			Architecture: importConfig.Import.Architecture,
 		}
 		err = po.Run(ctx, reportFilePaths, outFilePaths)
 		if err != nil {
@@ -347,9 +350,10 @@ func Program(args []string) error {
 		}
 
 		err := registry.ImportOption{
-			Registries: registries,
-			Imgs:       imgPs,
-			All:        all,
+			Registries:   registries,
+			Imgs:         imgPs,
+			All:          all,
+			Architecture: importConfig.Import.Architecture,
 		}.Run(ctx)
 		if err != nil {
 			return err

--- a/pkg/registry/importOption.go
+++ b/pkg/registry/importOption.go
@@ -15,7 +15,8 @@ type ImportOption struct {
 	Imgs       []*Image
 	Registries []Registry
 
-	All bool
+	Architecture *string
+	All          bool
 }
 
 func (io ImportOption) Run(ctx context.Context) error {
@@ -51,7 +52,7 @@ func (io ImportOption) Run(ctx context.Context) error {
 						if err != nil {
 							return err
 						}
-						manifest, err := reg.Push(egCtx, i.Registry, name, i.Tag)
+						manifest, err := reg.Push(egCtx, i.Registry, name, i.Tag, io.Architecture)
 						if err != nil {
 							return err
 						}

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -26,6 +26,7 @@ update: false
 all: false
 import:
   enabled: true
+  architecture: "linux/amd64"
   copacetic:
     enabled: true
     ignoreErrors: true
@@ -104,6 +105,7 @@ registries:
 | `all`         | bool         | false    |  false | Toggle import of all images regardless if they exist in the registries defined in `registries` |
 | `import`      | object       | nil      | false |  If import is enabled, images will be pushed to the defined registries. If copacetic is enabled, images will be patched if possible. Finally, in the import section Cosign can be configured to sign the images after pushing to the registries. See table blow for full configuration options. |
 | `import.enabled`   | bool   | false   | false | Enable import of charts and artifacts to registries |
+| `import.architecture`   | *string   | nil   | false | Specify desired container image architecture |
 | `import.copacetic.enabled`      | bool   | false   |  false | Enable Copacetic                            |
 | `import.copacetic.ignoreErrors` | bool   | true    |  false | Ignore errors during Copacetic patching     |
 | `import.copacetic.buildkitd.addr`       | string |         | true | Address to Buildkit                                   |


### PR DESCRIPTION
Added option to specify desired container image architecture when importing images.
I have tried to test this with amd64/arm64 and it works with importing images without patching with copacetic.

When patching with Copacetic, buildkit errors when trying to patch. I image when running buildkit on arm64 hardware it will work.

Closes #42