### PR TITLE
[feat] add feature to import user defined images

### DIFF
--- a/example/helmper.yaml
+++ b/example/helmper.yaml
@@ -2,6 +2,8 @@ k8s_version: 1.27.9
 verbose: true
 update: false
 all: false
+parser:
+  useCustomValues: false
 import:
   enabled: true
   architecture: "linux/amd64"

--- a/example/helmper.yaml
+++ b/example/helmper.yaml
@@ -68,6 +68,10 @@ charts:
     repo:
       name: prometheus-community
       url: https://prometheus-community.github.io/helm-charts/
+images:
+  - ref: docker.io/library/helloworld:latest
+  - ref: docker.io/library/redis:latest
+    patch: false
 registries:
   - name: registry
     url: 0.0.0.0:5000

--- a/internal/bootstrap/viper.go
+++ b/internal/bootstrap/viper.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ChristofferNissen/helmper/pkg/helm"
 	"github.com/ChristofferNissen/helmper/pkg/registry"
 	"github.com/ChristofferNissen/helmper/pkg/util/state"
+	"github.com/distribution/reference"
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -52,6 +53,10 @@ type ImportConfigSection struct {
 	} `yaml:"import"`
 }
 
+type imageConfigSection struct {
+	Ref string `yaml:"ref"`
+}
+
 type registryConfigSection struct {
 	Name      string `yaml:"name"`
 	URL       string `yaml:"url"`
@@ -61,6 +66,7 @@ type registryConfigSection struct {
 
 type config struct {
 	ImportConfig ImportConfigSection     `yaml:"import"`
+	Images       []imageConfigSection    `yaml:"images"`
 	Registries   []registryConfigSection `yaml:"registries"`
 }
 
@@ -104,18 +110,18 @@ func LoadViperConfiguration(_ []string) (*viper.Viper, error) {
 	viper.Set("input", inputConf)
 
 	// Unmarshal registries config section
-	regConf := config{}
-	if err := viper.Unmarshal(&regConf); err != nil {
-		return nil, err
-	}
-	viper.Set("config", regConf)
-
-	conf := ImportConfigSection{}
+	conf := config{}
 	if err := viper.Unmarshal(&conf); err != nil {
 		return nil, err
 	}
+	viper.Set("config", conf)
 
-	if conf.Import.Cosign.Enabled && conf.Import.Cosign.KeyRef == "" {
+	importConf := ImportConfigSection{}
+	if err := viper.Unmarshal(&importConf); err != nil {
+		return nil, err
+	}
+
+	if importConf.Import.Cosign.Enabled && importConf.Import.Cosign.KeyRef == "" {
 		s := `
 import:
   cosign:
@@ -125,20 +131,20 @@ import:
 		return nil, xerrors.Errorf("You have enabled cosign but did not specify any keyRef. Please specify a keyRef and try again..\nExample config:\n%s", s)
 	}
 
-	if conf.Import.Cosign.Enabled && conf.Import.Cosign.KeyRefPass == nil {
+	if importConf.Import.Cosign.Enabled && importConf.Import.Cosign.KeyRefPass == nil {
 		v := os.Getenv("COSIGN_PASSWORD")
 		slog.Info("KeyRefPass is nil, using value of COSIGN_PASSWORD environment variable")
-		conf.Import.Cosign.KeyRefPass = &v
+		importConf.Import.Cosign.KeyRefPass = &v
 	}
 
-	if conf.Import.Copacetic.Enabled {
+	if importConf.Import.Copacetic.Enabled {
 
-		if conf.Import.Copacetic.Buildkitd.Addr == "" {
+		if importConf.Import.Copacetic.Buildkitd.Addr == "" {
 			// use local socket by default
-			conf.Import.Copacetic.Buildkitd.Addr = "unix:///run/buildkit/buildkitd.sock"
+			importConf.Import.Copacetic.Buildkitd.Addr = "unix:///run/buildkit/buildkitd.sock"
 		}
 
-		if conf.Import.Copacetic.Trivy.Addr == "" {
+		if importConf.Import.Copacetic.Trivy.Addr == "" {
 			s := `
 import:
   copacetic:
@@ -153,7 +159,7 @@ import:
 		})
 		viper.WatchConfig()
 
-		if conf.Import.Copacetic.Output.Reports.Folder == "" {
+		if importConf.Import.Copacetic.Output.Reports.Folder == "" {
 			s := `
 copacetic:
   enabled: true
@@ -164,7 +170,7 @@ copacetic:
 			return nil, xerrors.Errorf("You have enabled copacetic patching but did not specify the path to the reports output folder'. Please add the value and try again\nExample:\n%s", s)
 		}
 
-		if conf.Import.Copacetic.Output.Tars.Folder == "" {
+		if importConf.Import.Copacetic.Output.Tars.Folder == "" {
 			s := `
 copacetic:
   enabled: true
@@ -177,10 +183,10 @@ copacetic:
 
 	}
 
-	viper.Set("importConfig", conf)
+	viper.Set("importConfig", importConf)
 
 	rs := []registry.Registry{}
-	for _, r := range regConf.Registries {
+	for _, r := range conf.Registries {
 		rs = append(rs,
 			registry.Registry{
 				Name:      r.Name,
@@ -189,6 +195,47 @@ copacetic:
 			})
 	}
 	state.SetValue(viper, "registries", rs)
+
+	// TODO. Concert config.Images to Image{}
+	is := []registry.Image{}
+	for _, i := range conf.Images {
+		ref, err := reference.ParseAnyReference(i.Ref)
+		if err != nil {
+			return viper, err
+		}
+
+		img := registry.Image{}
+		switch r := ref.(type) {
+		case reference.Canonical:
+			d := reference.Domain(r)
+			p := reference.Path(r)
+
+			img.Registry = d
+			img.Repository = p
+			img.Digest = r.Digest().String()
+			img.UseDigest = true
+
+			if t, ok := r.(reference.Tagged); ok {
+				img.Tag = t.Tag()
+			}
+
+			is = append(is, img)
+
+		case reference.NamedTagged:
+			d := reference.Domain(r)
+			p := reference.Path(r)
+
+			img.Registry = d
+			img.Repository = p
+			img.Tag = r.Tag()
+			img.UseDigest = false
+
+			is = append(is, img)
+
+		}
+
+	}
+	state.SetValue(viper, "images", is)
 
 	viper.OnConfigChange(func(e fsnotify.Event) {
 		slog.Info("Config file changed. It will not take effect before next run.", slog.String("config", e.Name))

--- a/internal/bootstrap/viper.go
+++ b/internal/bootstrap/viper.go
@@ -54,7 +54,8 @@ type ImportConfigSection struct {
 }
 
 type imageConfigSection struct {
-	Ref string `yaml:"ref"`
+	Ref   string `yaml:"ref"`
+	Patch *bool  `yaml:"patch"`
 }
 
 type registryConfigSection struct {
@@ -204,7 +205,9 @@ copacetic:
 			return viper, err
 		}
 
-		img := registry.Image{}
+		img := registry.Image{
+			Patch: i.Patch,
+		}
 		switch r := ref.(type) {
 		case reference.Canonical:
 			d := reference.Domain(r)

--- a/internal/bootstrap/viper.go
+++ b/internal/bootstrap/viper.go
@@ -65,7 +65,12 @@ type registryConfigSection struct {
 	PlainHTTP bool   `yaml:"plainHTTP"`
 }
 
+type ParserConfigSection struct {
+	UseCustomValues bool `yaml:"useCustomValues"`
+}
+
 type config struct {
+	Parser       ParserConfigSection     `yaml:"parser"`
 	ImportConfig ImportConfigSection     `yaml:"import"`
 	Images       []imageConfigSection    `yaml:"images"`
 	Registries   []registryConfigSection `yaml:"registries"`
@@ -116,6 +121,7 @@ func LoadViperConfiguration(_ []string) (*viper.Viper, error) {
 		return nil, err
 	}
 	viper.Set("config", conf)
+	viper.Set("parserConfig", conf.Parser)
 
 	importConf := ImportConfigSection{}
 	if err := viper.Unmarshal(&importConf); err != nil {

--- a/internal/program.go
+++ b/internal/program.go
@@ -173,6 +173,20 @@ func Program(args []string) error {
 		}
 
 		for _, i := range imgs {
+
+			if i.Patch != nil {
+				if !*i.Patch {
+					ref, err := i.String()
+					if err != nil {
+						return err
+					}
+					slog.Debug("User defined image should not be patched",
+						slog.String("image", ref))
+					push = append(push, &i)
+					continue
+				}
+			}
+
 			ref, _ := i.String()
 			r, err := so.Scan(ref)
 			if err != nil {

--- a/internal/program.go
+++ b/internal/program.go
@@ -44,6 +44,7 @@ func Program(args []string) error {
 		verbose      bool                          = state.GetValue[bool](viper, "verbose")
 		update       bool                          = state.GetValue[bool](viper, "update")
 		all          bool                          = state.GetValue[bool](viper, "all")
+		parserConfig bootstrap.ParserConfigSection = state.GetValue[bootstrap.ParserConfigSection](viper, "parserConfig")
 		importConfig bootstrap.ImportConfigSection = state.GetValue[bootstrap.ImportConfigSection](viper, "importConfig")
 		registries   []registry.Registry           = state.GetValue[[]registry.Registry](viper, "registries")
 		images       []registry.Image              = state.GetValue[[]registry.Image](viper, "images")
@@ -83,6 +84,7 @@ func Program(args []string) error {
 	slog.Debug("Starting parsing user specified chart(s) for images..")
 	co := helm.ChartOption{
 		ChartCollection: &charts,
+		UseCustomValues: parserConfig.UseCustomValues,
 	}
 	chartImageHelmValuesMap, err := co.Run(
 		ctx,

--- a/internal/program.go
+++ b/internal/program.go
@@ -130,7 +130,7 @@ func Program(args []string) error {
 
 	// Import charts to registries
 	switch {
-	case importConfig.Import.Enabled:
+	case importConfig.Import.Enabled && len(charts.Charts) > 0:
 		err := helm.ChartImportOption{
 			Registries:      registries,
 			ChartCollection: &charts,
@@ -187,7 +187,10 @@ func Program(args []string) error {
 				}
 			}
 
-			ref, _ := i.String()
+			ref, err := i.String()
+			if err != nil {
+				return err
+			}
 			r, err := so.Scan(ref)
 			if err != nil {
 				return err

--- a/internal/program.go
+++ b/internal/program.go
@@ -46,6 +46,7 @@ func Program(args []string) error {
 		all          bool                          = state.GetValue[bool](viper, "all")
 		importConfig bootstrap.ImportConfigSection = state.GetValue[bootstrap.ImportConfigSection](viper, "importConfig")
 		registries   []registry.Registry           = state.GetValue[[]registry.Registry](viper, "registries")
+		images       []registry.Image              = state.GetValue[[]registry.Image](viper, "images")
 		charts       helm.ChartCollection          = state.GetValue[helm.ChartCollection](viper, "input")
 		opts         []helm.Option                 = []helm.Option{
 			helm.K8SVersion(k8sVersion),
@@ -90,6 +91,18 @@ func Program(args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Add in images from config
+	placeHolder := helm.Chart{
+		Name:    "images",
+		Version: "0.0.0",
+	}
+	m := map[*registry.Image][]string{}
+	for _, i := range images {
+		m[&i] = []string{}
+	}
+	chartImageHelmValuesMap[placeHolder] = m
+
 	// Output table of image to helm chart value path
 	output.RenderHelmValuePathToImageTable(chartImageHelmValuesMap)
 	slog.Debug("Parsing of user specified chart(s) completed")

--- a/internal/program_test.go
+++ b/internal/program_test.go
@@ -28,6 +28,47 @@ import (
 // ArgoCD
 // Harbor
 
+func TestFindImagesWithoutCharts(t *testing.T) {
+
+	// Arrange
+	ctx := context.TODO()
+
+	charts := helm.ChartCollection{
+		Charts: []helm.Chart{},
+	}
+
+	co := helm.ChartOption{
+		ChartCollection: &charts,
+	}
+	_, err := co.ChartCollection.SetupHelm()
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedChartCount := 0
+	expectedImageCount := 0
+
+	// Act
+	data, err := co.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert
+	if len(data) != expectedChartCount {
+		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
+	}
+
+	imageCount := 0
+	for _, images := range data {
+		imageCount = imageCount + len(images)
+	}
+
+	if imageCount != expectedImageCount {
+		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
+	}
+}
+
 func TestFindImagesInHelmChartsOnPrometheusChart(t *testing.T) {
 	// t.Parallel()
 

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -95,7 +95,9 @@ func (c Chart) ResolveVersions() ([]string, error) {
 
 func (c Chart) ResolveVersion() (string, error) {
 
-	s, err := semver.Parse(strings.TrimPrefix(c.Version, "v"))
+	v := strings.ReplaceAll(c.Version, "*", "0")
+
+	s, err := semver.Parse(strings.TrimPrefix(v, "v"))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/helm/chartImportOption.go
+++ b/pkg/helm/chartImportOption.go
@@ -97,6 +97,10 @@ func (opt ChartImportOption) Run(ctx context.Context, setters ...Option) error {
 
 	for _, c := range charts {
 
+		if c.Name == "images" {
+			continue
+		}
+
 		for _, r := range opt.Registries {
 
 			_, err := r.Exist(ctx, "charts/"+c.Name, c.Version)

--- a/pkg/helm/chartOption.go
+++ b/pkg/helm/chartOption.go
@@ -159,6 +159,11 @@ func (co ChartOption) Run(ctx context.Context, setters ...Option) (ChartData, er
 		eg.Go(func() error {
 			defer close(channel)
 
+			if len(charts.Charts) == 0 {
+				// nothing to process
+				return nil
+			}
+
 			bar := progressbar.NewOptions(len(charts.Charts),
 				progressbar.OptionSetWriter(ansi.NewAnsiStdout()), // "github.com/k0kubun/go-ansi"
 				progressbar.OptionEnableColorCodes(true),

--- a/pkg/helm/chartOption.go
+++ b/pkg/helm/chartOption.go
@@ -75,6 +75,7 @@ type imageInfo struct {
 
 type ChartOption struct {
 	ChartCollection *ChartCollection
+	UseCustomValues bool
 }
 
 func determineTag(ctx context.Context, k8sv string, img *registry.Image, plainHTTP bool) bool {
@@ -262,7 +263,7 @@ func (co ChartOption) Run(ctx context.Context, setters ...Option) (ChartData, er
 				}
 
 				// find images and validate according to values
-				imageMap := findImageReferences(chart.Values, values)
+				imageMap := findImageReferences(chart.Values, values, co.UseCustomValues)
 
 				// check that images are available from registries
 				if imageMap == nil {

--- a/pkg/helm/parser.go
+++ b/pkg/helm/parser.go
@@ -28,7 +28,7 @@ func ConditionMet(condition string, values map[string]any) bool {
 }
 
 // traverse helm chart values data structure
-func findImageReferencesAcc(data map[string]any, values map[string]any, acc string) map[*registry.Image][]string {
+func findImageReferencesAcc(data map[string]any, values map[string]any, useCustomValues bool, acc string) map[*registry.Image][]string {
 	res := make(map[*registry.Image][]string)
 
 	i := registry.Image{}
@@ -46,45 +46,75 @@ func findImageReferencesAcc(data map[string]any, values map[string]any, acc stri
 
 			switch k {
 			case "registry":
-				s, ok := values[k].(string)
-				if ok {
-					i.Registry = s
-				} else {
+				switch useCustomValues {
+				case true:
+					s, ok := values[k].(string)
+					if ok {
+						i.Registry = s
+					} else {
+						i.Registry = v
+					}
+				case false:
 					i.Registry = v
 				}
 			case "repository":
-				s, ok := values[k].(string)
-				if ok {
-					i.Repository = s
-				} else {
+				switch useCustomValues {
+				case true:
+					s, ok := values[k].(string)
+					if ok {
+						i.Repository = s
+					} else {
+						i.Repository = v
+					}
+				case false:
 					i.Repository = v
 				}
 			case "image":
-				s, ok := values[k].(string)
-				if ok {
-					i.Repository = s
-				} else {
+				switch useCustomValues {
+				case true:
+					s, ok := values[k].(string)
+					if ok {
+						i.Repository = s
+					} else {
+						i.Repository = v
+					}
+				case false:
 					i.Repository = v
 				}
 			case "tag":
-				s, ok := values[k].(string)
-				if ok {
-					i.Tag = s
-				} else {
+				switch useCustomValues {
+				case true:
+					s, ok := values[k].(string)
+					if ok {
+						i.Tag = s
+					} else {
+						i.Tag = v
+					}
+				case false:
 					i.Tag = v
 				}
 			case "digest":
-				s, ok := values[k].(string)
-				if ok {
-					i.Digest = s
-				} else {
+				switch useCustomValues {
+				case true:
+					s, ok := values[k].(string)
+					if ok {
+						i.Digest = s
+					} else {
+						i.Digest = v
+					}
+				case false:
 					i.Digest = v
 				}
 			case "sha":
-				s, ok := values[k].(string)
-				if ok {
-					i.Digest = s
-				} else {
+				switch useCustomValues {
+				case true:
+					s, ok := values[k].(string)
+					if ok {
+						i.Digest = s
+					} else {
+						i.Digest = v
+					}
+				case false:
 					i.Digest = v
 				}
 			default:
@@ -115,7 +145,7 @@ func findImageReferencesAcc(data map[string]any, values map[string]any, acc stri
 			// if enabled, parse nested section
 			if enabled {
 				path := ternary.Ternary(acc == "", k, fmt.Sprintf("%s.%s", acc, k))
-				nestedRes := findImageReferencesAcc(v, values[k].(map[string]any), path)
+				nestedRes := findImageReferencesAcc(v, values[k].(map[string]any), useCustomValues, path)
 				for k, v := range nestedRes {
 					res[k] = v
 				}
@@ -126,6 +156,6 @@ func findImageReferencesAcc(data map[string]any, values map[string]any, acc stri
 	return res
 }
 
-func findImageReferences(data map[string]any, values map[string]any) map[*registry.Image][]string {
-	return findImageReferencesAcc(data, values, "")
+func findImageReferences(data map[string]any, values map[string]any, useCustomValues bool) map[*registry.Image][]string {
+	return findImageReferencesAcc(data, values, useCustomValues, "")
 }

--- a/pkg/helm/parser.go
+++ b/pkg/helm/parser.go
@@ -46,17 +46,47 @@ func findImageReferencesAcc(data map[string]any, values map[string]any, acc stri
 
 			switch k {
 			case "registry":
-				i.Registry = v
+				s, ok := values[k].(string)
+				if ok {
+					i.Registry = s
+				} else {
+					i.Registry = v
+				}
 			case "repository":
-				i.Repository = v
+				s, ok := values[k].(string)
+				if ok {
+					i.Repository = s
+				} else {
+					i.Repository = v
+				}
 			case "image":
-				i.Repository = v
+				s, ok := values[k].(string)
+				if ok {
+					i.Repository = s
+				} else {
+					i.Repository = v
+				}
 			case "tag":
-				i.Tag = v
+				s, ok := values[k].(string)
+				if ok {
+					i.Tag = s
+				} else {
+					i.Tag = v
+				}
 			case "digest":
-				i.Digest = v
+				s, ok := values[k].(string)
+				if ok {
+					i.Digest = s
+				} else {
+					i.Digest = v
+				}
 			case "sha":
-				i.Digest = v
+				s, ok := values[k].(string)
+				if ok {
+					i.Digest = s
+				} else {
+					i.Digest = v
+				}
 			default:
 				found = false
 			}

--- a/pkg/registry/image.go
+++ b/pkg/registry/image.go
@@ -15,6 +15,7 @@ type Image struct {
 	Tag        string
 	Digest     string
 	UseDigest  bool
+	Patch      *bool
 }
 
 func (i Image) TagOrDigest() (string, error) {

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -90,6 +90,7 @@ charts:
       url: https://prometheus-community.github.io/helm-charts/
 images:
 - ref: docker.io/library/busybox:latest@sha256:7cc4b5aefd1d0cadf8d97d4350462ba51c694ebca145b08d7d41b41acc8db5aa
+  patch: false
 registries:
   - name: registry
     url: 0.0.0.0:5000
@@ -141,6 +142,7 @@ registries:
 | `charts[].repo.pass_credentials_all`     | bool   | false   | false | Pass credentials to dependency charts repositories |
 | `images`     | list(object)   | [] | false | Additional container images to include in import |
 | `images.ref` | string  | | true | Container image reference |
+| `images.patch` | *bool  | nil | false | Define if container image should be patched with Trivy/Copacetic |
 | `registries`  | list(object) | [] | false | Defines which registries to import to |
 | `registries[].name`      | string |         | true | Name of registry                    |
 | `registries[].url`       | string |         | true | URL to registry                     |

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -24,6 +24,8 @@ k8s_version: 1.27.9
 verbose: true
 update: false
 all: false
+parser:
+  useCustomValues: false
 import:
   enabled: true
   architecture: "linux/amd64"
@@ -106,6 +108,8 @@ registries:
 | `verbose`     | bool         | false    |  false | Toggle verbose output |
 | `update`      | bool         | false    |  false | Toggle update to latest chart version for each specified chart in `charts` |
 | `all`         | bool         | false    |  false | Toggle import of all images regardless if they exist in the registries defined in `registries` |
+| `parser`         | object         | nil    |  false | Adjust how Helmper parses charts |
+| `parser.useCustomValues`         | bool         | false    |  false | Use user defined values for image parsing |
 | `import`      | object       | nil      | false |  If import is enabled, images will be pushed to the defined registries. If copacetic is enabled, images will be patched if possible. Finally, in the import section Cosign can be configured to sign the images after pushing to the registries. See table blow for full configuration options. |
 | `import.enabled`   | bool   | false   | false | Enable import of charts and artifacts to registries |
 | `import.architecture`   | *string   | nil   | false | Specify desired container image architecture |

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -88,6 +88,8 @@ charts:
     repo:
       name: prometheus-community
       url: https://prometheus-community.github.io/helm-charts/
+images:
+- ref: docker.io/library/busybox:latest@sha256:7cc4b5aefd1d0cadf8d97d4350462ba51c694ebca145b08d7d41b41acc8db5aa
 registries:
   - name: registry
     url: 0.0.0.0:5000
@@ -124,7 +126,7 @@ registries:
 | `import.cosign.keyRefPass`        | string |         | true | Cosign private key password |
 | `import.cosign.allowInsecure`     | bool   | false   | false | Disable TLS verification    |
 | `import.cosign.allowHTTPRegistry` | bool   | false   | false | Allow HTTP instead of HTTPS |
-| `charts`      | list(object) | | true | Defines which charts to target |
+| `charts`      | list(object) | [] | false | Defines which charts to target |
 | `charts[].name`           | string |         | true | Chart name                                          |
 | `charts[].version`        | string |         | true | Desired version of chart. Supports semver literal or semver ranges (semantic version spec 2.0) |
 | `charts[].valuesFilePath` | string | ""      | false | Path to custom values.yaml to customize importing   |
@@ -137,6 +139,8 @@ registries:
 | `charts[].repo.caFile`                   | string | ""      | false | Path to custom certificate authority               |
 | `charts[].repo.insecure_skip_tls_verify` | bool   | false   | false | Skip TLS verify / Disable SSL                      |
 | `charts[].repo.pass_credentials_all`     | bool   | false   | false | Pass credentials to dependency charts repositories |
+| `images`     | list(object)   | [] | false | Additional container images to include in import |
+| `images.ref` | string  | | true | Container image reference |
 | `registries`  | list(object) | [] | false | Defines which registries to import to |
 | `registries[].name`      | string |         | true | Name of registry                    |
 | `registries[].url`       | string |         | true | URL to registry                     |
@@ -147,7 +151,8 @@ registries:
 
 The `charts` configuration option defines which charts to import.
 
-| Key | Type  | Default | Required | Description |
+| Key | Type  | Default | R| `images.patch`     | bool  |  | true | Container image reference |
+equired | Description |
 |-|-|-|-|-|
 | `charts[].name`           | string |         | true | Chart name                                          |
 | `charts[].version`        | string |         | true | Desired version of chart. Supports semver literal or semver ranges (semantic version spec 2.0) |
@@ -178,6 +183,11 @@ Helmper supports all configuration options for Helm Repositories available in th
 **OCI Registry**
 
 Not implemented yet. Coming soon.
+
+## Images
+
+Helmper provides the option to include additional images in the import flow not extracted from one of the defined Helm Charts.
+Simply define the additional images in the `images` configuration option.
 
 ## Buildkit
 


### PR DESCRIPTION
Add option to define extra images to be included in import flow

Images are defined in helmper.yaml

```yaml
images:
- ref: docker.io/library/helloworld:latest
- ref: docker.io/library/redis:latest
  patch: false
```

Closes #39 

Introduce flag to let the user decide if they want to take values from user defined values.yaml during Helmper Image parsing.

```yaml
parser:
  useCustomValues: false
```

This flag is intended to allow users to overwrite certain images if they know that the correct image is not in the default chart values. One example is Cilium, which has the following section to define cilium-operator:

```yaml
operator:
  # -- Enable the cilium-operator component (required).
  enabled: true
  # -- Roll out cilium-operator pods automatically when configmap is updated.
  rollOutPods: false
  # -- cilium-operator image.
  image:
    # @schema
    # type: [null, string]
    # @schema
    override: ~
    repository: "quay.io/cilium/operator"
    tag: "v1.16.0-rc.0"
    # operator-generic-digest
    genericDigest: "sha256:78b9951cd6d92e7c954b9d7d2791cf52c83895441147deec3906c03363fd1169"
    # operator-azure-digest
    azureDigest: "sha256:388192c967442fbfa791e152df1bfa55ff0d2ebcdbc57bb4b3f52c58dd8eb64e"
    # operator-aws-digest
    awsDigest: "sha256:4724f2420488e73a2191a80ab190ab0efe6f2ca15f4b552d1f2ee1870bb8b0c2"
    # operator-alibabacloud-digest
    alibabacloudDigest: "sha256:b5e2ee8de5345bfaee60d279ec5e010c724d33c9f6a66b58c29d5500300caf56"
    useDigest: true
    pullPolicy: "IfNotPresent"
    suffix: ""
```

This results in Helmper imports `quay.io/cilium/operator` but the deployment actually uses `quay.io/cilium/operator-generic` (due to helpers file on `helm template`)

With this flag, users can overwrite the image from a values.yaml

```yaml
operator:
  image:
    repository: "quay.io/cilium/operator-generic"
```

Closes #50 