### PR TITLE
[fix] added support for OCI repository for Helm Charts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,6 @@
             "request": "launch",
             "mode": "auto",
             "program": "cmd/helmper/main.go",
-            "args": ["--f", "config.yaml"]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,8 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "cmd/helmper/main.go"
+            "program": "cmd/helmper/main.go",
+            "args": ["--f", "config.yaml"]
         }
     ]
 }

--- a/example/helmper.yaml
+++ b/example/helmper.yaml
@@ -36,6 +36,7 @@ charts:
 - name: loki
   version: 5.38.0
   valuesFilePath: /workspace/.in/values/loki/values.yaml
+  plainHTTP: false
   repo:
     name: grafana
     url: https://grafana.github.io/helm-charts/

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"context"
-	"log"
 	"log/slog"
 	"os"
 	"strings"
@@ -65,7 +64,7 @@ func RenderChartTable(charts *helm.ChartCollection, setters ...Option) {
 		// Check for latest version of chart
 		latest, err := c.LatestVersion()
 		if err != nil {
-			log.Fatal(err)
+			slog.Error(err.Error(), slog.String("chart", c.Name), slog.String("repo", c.Repo.URL), slog.String("version", c.Version))
 		}
 
 		_, chartRef, values, _ := c.Read(args.Update)

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"context"
+	"log"
 	"log/slog"
 	"os"
 	"strings"
@@ -62,7 +63,10 @@ func RenderChartTable(charts *helm.ChartCollection, setters ...Option) {
 	for _, c := range charts.Charts {
 
 		// Check for latest version of chart
-		latest, _ := c.LatestVersion()
+		latest, err := c.LatestVersion()
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		_, chartRef, values, _ := c.Read(args.Update)
 		valuesType := determinePathType(c.ValuesFilePath)

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -240,7 +240,7 @@ func (c Chart) pullTar() (string, error) {
 	settings := cli.New()
 
 	// You can pass an empty string instead of settings.Namespace() to list
-	// all namespacesargo-cd
+	// all namespaces
 	// HELM_DRIVER can be one of: [ configmap, secret, sql ]
 	HelmDriver := "configmap"
 	actionConfig := new(action.Configuration)
@@ -302,11 +302,6 @@ func (c Chart) Push(registry string, insecure bool, plainHTTP bool) (string, err
 
 	return push.Run(path, registry)
 }
-
-// const (
-// 	helmChartMetaMediaType    = "application/vnd.cncf.helm.chart.meta.v1+json"
-// 	helmChartContentMediaType = "application/vnd.cncf.helm.chart.content.v1+tar"
-// )
 
 func (c Chart) Pull() (string, error) {
 
@@ -475,7 +470,6 @@ func (c Chart) Locate() (string, error) {
 			}
 		}
 
-		// "/home/cn/.cache/helm/repository/argo-cd-5.51.6.tgz"
 		return chartPath, nil
 	}
 }

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -375,7 +375,7 @@ func (c Chart) Locate() (string, error) {
 	switch {
 	case strings.HasPrefix(c.Repo.URL, "oci://"):
 
-		ref := c.Repo.URL + c.Name
+		ref := strings.TrimSuffix(c.Repo.URL, "/") + "/" + c.Name
 
 		co := action.ChartPathOptions{
 			CaFile:                c.Repo.CAFile,

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"log/slog"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/ChristofferNissen/helmper/pkg/util/file"
 	"golang.org/x/xerrors"
+	"oras.land/oras-go/v2/registry/remote"
 
 	"github.com/blang/semver/v4"
 	"helm.sh/helm/v3/pkg/action"
@@ -44,6 +46,7 @@ type Chart struct {
 	Repo           repo.Entry `json:"repo"`
 	Parent         *Chart
 	Images         *Images `json:"images"`
+	PlainHTTP      bool    `json:"plainHTTP"`
 }
 
 // AddChartRepositoryToHelmRepositoryFile adds repository to Helm repository.yml to enable querying/pull
@@ -149,6 +152,42 @@ func (c Chart) ResolveVersion() (string, error) {
 func (c Chart) LatestVersion() (string, error) {
 	config := cli.New()
 
+	if strings.HasPrefix(c.Repo.URL, "oci://") {
+
+		ref := strings.TrimPrefix(strings.TrimSuffix(c.Repo.URL, "/")+"/"+c.Name, "oci://")
+
+		repo, err := remote.NewRepository(ref)
+		if err != nil {
+			return "", err
+		}
+
+		repo.PlainHTTP = c.PlainHTTP
+
+		l := c.Version
+		err = repo.Tags(context.TODO(), c.Version, func(tags []string) error {
+			vs := []semver.Version{}
+
+			for _, t := range tags {
+				s, err := semver.Parse(t)
+				if err != nil {
+					// non semver tag
+					continue
+				}
+				vs = append(vs, s)
+			}
+
+			semver.Sort(vs)
+			l = vs[len(vs)-1].String()
+
+			return nil
+		})
+		if err != nil {
+			return "", err
+		}
+
+		return l, nil
+	}
+
 	indexPath := fmt.Sprintf("%s/%s-index.yaml", config.RepositoryCache, c.Repo.Name)
 	index, err := repo.LoadIndexFile(indexPath)
 	if err != nil {
@@ -191,7 +230,7 @@ func (c Chart) pullTar() (string, error) {
 		CertFile:              c.Repo.CertFile,
 		KeyFile:               c.Repo.KeyFile,
 		InsecureSkipTLSverify: c.Repo.InsecureSkipTLSverify,
-		PlainHTTP:             u.Scheme == "https",
+		PlainHTTP:             c.PlainHTTP || u.Scheme == "https",
 		Password:              c.Repo.Password,
 		PassCredentialsAll:    c.Repo.PassCredentialsAll,
 		RepoURL:               c.Repo.URL,
@@ -201,7 +240,7 @@ func (c Chart) pullTar() (string, error) {
 	settings := cli.New()
 
 	// You can pass an empty string instead of settings.Namespace() to list
-	// all namespaces
+	// all namespacesargo-cd
 	// HELM_DRIVER can be one of: [ configmap, secret, sql ]
 	HelmDriver := "configmap"
 	actionConfig := new(action.Configuration)
@@ -263,6 +302,11 @@ func (c Chart) Push(registry string, insecure bool, plainHTTP bool) (string, err
 
 	return push.Run(path, registry)
 }
+
+// const (
+// 	helmChartMetaMediaType    = "application/vnd.cncf.helm.chart.meta.v1+json"
+// 	helmChartContentMediaType = "application/vnd.cncf.helm.chart.content.v1+tar"
+// )
 
 func (c Chart) Pull() (string, error) {
 
@@ -331,53 +375,109 @@ func (c Chart) Pull() (string, error) {
 
 func (c Chart) Locate() (string, error) {
 	config := cli.New()
-
-	u, err := url.Parse(c.Repo.URL)
-	if err != nil {
-		return "", err
-	}
-
-	co := action.ChartPathOptions{
-		CaFile:                c.Repo.CAFile,
-		CertFile:              c.Repo.CertFile,
-		KeyFile:               c.Repo.KeyFile,
-		InsecureSkipTLSverify: c.Repo.InsecureSkipTLSverify,
-		PlainHTTP:             u.Scheme == "https",
-		Password:              c.Repo.Password,
-		PassCredentialsAll:    c.Repo.PassCredentialsAll,
-		RepoURL:               c.Repo.URL,
-		Username:              c.Repo.Username,
-		Version:               c.Version,
-	}
-
 	helmCacheHome := config.EnvVars()["HELM_CACHE_HOME"]
 
-	chartPath, err := co.LocateChart(c.Name, config)
-	if err != nil {
-		// subcharts nested in parent charts source?
-		if c.Parent != nil {
-			path := filepath.Join(helmCacheHome, c.Parent.Name, "charts", c.Name)
-			if file.Exists(path) {
-				return path, nil
-			}
+	switch {
+	case strings.HasPrefix(c.Repo.URL, "oci://"):
+
+		ref := c.Repo.URL + c.Name
+
+		co := action.ChartPathOptions{
+			CaFile:                c.Repo.CAFile,
+			CertFile:              c.Repo.CertFile,
+			KeyFile:               c.Repo.KeyFile,
+			InsecureSkipTLSverify: c.Repo.InsecureSkipTLSverify,
+			PassCredentialsAll:    c.Repo.PassCredentialsAll,
+			Username:              c.Repo.Username,
+			Password:              c.Repo.Password,
+			Version:               c.Version,
 		}
 
-		ma := downloader.Manager{
-			ChartPath:  chartPath,
-			SkipUpdate: false,
+		settings := cli.New()
+
+		// You can pass an empty string instead of settings.Namespace() to list
+		// all namespaces
+		// HELM_DRIVER can be one of: [ configmap, secret, sql ]
+		HelmDriver := "configmap"
+		actionConfig := new(action.Configuration)
+		if err := actionConfig.Init(
+			settings.RESTClientGetter(),
+			settings.Namespace(),
+			HelmDriver,
+			log.Printf,
+		); err != nil {
+			return "", err
 		}
-		err := ma.Update()
+
+		// Make temporary folder for tar archives
+		f, err := os.MkdirTemp(os.TempDir(), "untar")
+		if err != nil {
+			return "", err
+		}
+		defer os.RemoveAll(f)
+
+		opts := []action.PullOpt{
+			action.WithConfig(actionConfig),
+		}
+		pull := action.NewPullWithOpts(opts...)
+		pull.ChartPathOptions = co
+		pull.Settings = settings
+		pull.DestDir = helmCacheHome
+
+		_, err = pull.Run(ref)
 		if err != nil {
 			return "", err
 		}
 
-		chartPath, err := co.LocateChart(c.Name, config)
-		if err == nil {
-			return chartPath, nil
-		}
-	}
+		return fmt.Sprintf("%s/%s-%s.tgz", helmCacheHome, c.Name, c.Version), nil
+	default:
 
-	return chartPath, nil
+		u, err := url.Parse(c.Repo.URL)
+		if err != nil {
+			return "", err
+		}
+
+		co := action.ChartPathOptions{
+			CaFile:                c.Repo.CAFile,
+			CertFile:              c.Repo.CertFile,
+			KeyFile:               c.Repo.KeyFile,
+			InsecureSkipTLSverify: c.Repo.InsecureSkipTLSverify,
+			PlainHTTP:             u.Scheme == "https",
+			Password:              c.Repo.Password,
+			PassCredentialsAll:    c.Repo.PassCredentialsAll,
+			RepoURL:               c.Repo.URL,
+			Username:              c.Repo.Username,
+			Version:               c.Version,
+		}
+
+		chartPath, err := co.LocateChart(c.Name, config)
+		if err != nil {
+			// subcharts nested in parent charts source?
+			if c.Parent != nil {
+				path := filepath.Join(helmCacheHome, c.Parent.Name, "charts", c.Name)
+				if file.Exists(path) {
+					return path, nil
+				}
+			}
+
+			ma := downloader.Manager{
+				ChartPath:  chartPath,
+				SkipUpdate: false,
+			}
+			err := ma.Update()
+			if err != nil {
+				return "", err
+			}
+
+			chartPath, err := co.LocateChart(c.Name, config)
+			if err == nil {
+				return chartPath, nil
+			}
+		}
+
+		// "/home/cn/.cache/helm/repository/argo-cd-5.51.6.tgz"
+		return chartPath, nil
+	}
 }
 
 func (c Chart) Values() (map[string]any, error) {

--- a/pkg/helm/chartCollection.go
+++ b/pkg/helm/chartCollection.go
@@ -51,15 +51,6 @@ func (collection ChartCollection) SetupHelm(setters ...Option) (ChartCollection,
 		setter(args)
 	}
 
-	// for _, c := range collection.Charts {
-	// 	if !(strings.HasPrefix(c.Repo.URL, "http") || strings.HasPrefix(c.Repo.URL, "https")) {
-	// 		if strings.HasPrefix(c.Repo.URL, "oci") {
-	// 			return ChartCollection{}, xerrors.New("Helm only supports 'http and 'https' protocol for Helm Repositories. For oci protocol, see docs on the chart.oci configuration option in Helmper.")
-	// 		}
-	// 		return ChartCollection{}, xerrors.New("Helm only supports 'http and 'https' protocol for Helm Repositories")
-	// 	}
-	// }
-
 	// Add Helm Repos
 	err := collection.addToHelmRepositoryConfig()
 	if err != nil {

--- a/pkg/helm/chartCollection.go
+++ b/pkg/helm/chartCollection.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/ChristofferNissen/helmper/pkg/util/terminal"
-	"golang.org/x/xerrors"
 	"helm.sh/helm/v3/pkg/cli"
 )
 
@@ -16,6 +15,9 @@ type ChartCollection struct {
 
 func (collection ChartCollection) pull() error {
 	for _, chart := range collection.Charts {
+		if strings.HasPrefix(chart.Repo.URL, "oci://") {
+			continue
+		}
 		if _, err := chart.Pull(); err != nil {
 			return err
 		}
@@ -25,6 +27,9 @@ func (collection ChartCollection) pull() error {
 
 func (collection ChartCollection) addToHelmRepositoryConfig() error {
 	for _, c := range collection.Charts {
+		if strings.HasPrefix(c.Repo.URL, "oci://") {
+			continue
+		}
 		err := c.AddToHelmRepositoryFile()
 		if err != nil {
 			return err
@@ -46,14 +51,14 @@ func (collection ChartCollection) SetupHelm(setters ...Option) (ChartCollection,
 		setter(args)
 	}
 
-	for _, c := range collection.Charts {
-		if !(strings.HasPrefix(c.Repo.URL, "http") || strings.HasPrefix(c.Repo.URL, "https")) {
-			if strings.HasPrefix(c.Repo.URL, "oci") {
-				return ChartCollection{}, xerrors.New("Helm only supports 'http and 'https' protocol for Helm Repositories. For oci protocol, see docs on the chart.oci configuration option in Helmper.")
-			}
-			return ChartCollection{}, xerrors.New("Helm only supports 'http and 'https' protocol for Helm Repositories")
-		}
-	}
+	// for _, c := range collection.Charts {
+	// 	if !(strings.HasPrefix(c.Repo.URL, "http") || strings.HasPrefix(c.Repo.URL, "https")) {
+	// 		if strings.HasPrefix(c.Repo.URL, "oci") {
+	// 			return ChartCollection{}, xerrors.New("Helm only supports 'http and 'https' protocol for Helm Repositories. For oci protocol, see docs on the chart.oci configuration option in Helmper.")
+	// 		}
+	// 		return ChartCollection{}, xerrors.New("Helm only supports 'http and 'https' protocol for Helm Repositories")
+	// 	}
+	// }
 
 	// Add Helm Repos
 	err := collection.addToHelmRepositoryConfig()
@@ -79,7 +84,6 @@ func (collection ChartCollection) SetupHelm(setters ...Option) (ChartCollection,
 	// Expand collection if semantic version range
 	res := []Chart{}
 	for _, c := range collection.Charts {
-
 		vs, err := c.ResolveVersions()
 		if err != nil {
 			v, err := c.ResolveVersion()

--- a/pkg/helm/chartImportOption.go
+++ b/pkg/helm/chartImportOption.go
@@ -105,7 +105,7 @@ func (opt ChartImportOption) Run(ctx context.Context, setters ...Option) error {
 
 			_, err := r.Exist(ctx, "charts/"+c.Name, c.Version)
 			if err == nil {
-				slog.Info("Chart already present in registry. Skipping import", slog.String("chart", "charts/"+c.Name), slog.String("registry", "oci://"+r.URL))
+				slog.Info("Chart already present in registry. Skipping import", slog.String("chart", "charts/"+c.Name), slog.String("registry", "oci://"+r.URL), slog.String("version", c.Version))
 				continue
 			}
 

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -147,6 +147,7 @@ registries:
 | `charts`      | list(object) | [] | false | Defines which charts to target |
 | `charts[].name`           | string |         | true | Chart name                                          |
 | `charts[].version`        | string |         | true | Desired version of chart. Supports semver literal or semver ranges (semantic version spec 2.0) |
+| `charts[].plainHTTP`        | bool | false   | false | Use HTTP instead of HTTPS for repository protocol |
 | `charts[Name of the repository].valuesFilePath` | string | ""      | false | Path to custom values.yaml to customize importing   |
 | `charts[].images`                         | object        | nil    | false | Customization options for images in chart  |
 | `charts[].images.exclude`                 | list(object)  | []     | false | Defines which images to exclude from processing |

--- a/website/docs/intro_extended.md
+++ b/website/docs/intro_extended.md
@@ -69,6 +69,7 @@ k8s_version: 1.27.9
 charts:
 - name: prometheus
   version: 25.8.0
+  plainHTTP: false
   repo:
     name: prometheus-community
     url: https://prometheus-community.github.io/helm-charts/


### PR DESCRIPTION
Add support for OCI based Helm Chart registries

```yaml
...
charts:
- name: argo-cd
  plainHTTP: true
  repo:
    url: oci://localhost:5000/charts/
...
```

Closes #40 