### PR TITLE
[fix]  bug when chart version must be not semver (cert-manager uses v …

### DIFF
--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -247,7 +247,10 @@ func (c Chart) LatestVersion() (string, error) {
 			vs := []semver.Version{}
 
 			for _, t := range tags {
-				s, err := semver.Parse(t)
+
+				v, _ := strings.CutPrefix(t, "v")
+
+				s, err := semver.Parse(v)
 				if err != nil {
 					// non semver tag
 					continue

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -79,7 +79,9 @@ func (c Chart) AddToHelmRepositoryFile() error {
 
 func (c Chart) ResolveVersions() ([]string, error) {
 
-	r, err := semver.ParseRange(c.Version)
+	version, _ := strings.CutPrefix(c.Version, "v")
+
+	r, err := semver.ParseRange(version)
 	if err != nil {
 		// not a semver range
 		return nil, err
@@ -98,7 +100,9 @@ func (c Chart) ResolveVersions() ([]string, error) {
 	versionsInRange := []string{}
 	for _, v := range versions {
 
-		sv, err := semver.Parse(v.Version)
+		version, _ := strings.CutPrefix(v.Version, "v")
+
+		sv, err := semver.Parse(version)
 		if err != nil {
 			continue
 		}
@@ -193,7 +197,10 @@ func (c Chart) ResolveVersion() (string, error) {
 	versions := index.Entries[c.Name]
 
 	for _, v := range versions {
-		sv, err := semver.Parse(v.Version)
+
+		version, _ := strings.CutPrefix(v.Version, "v")
+
+		sv, err := semver.Parse(version)
 		switch {
 		case err != nil:
 			// not semver
@@ -392,7 +399,7 @@ func (c Chart) pullTar() (string, error) {
 	}
 
 	// Resolve filepath (wildcards) for dependency charts
-	matches, err := filepath.Glob(fmt.Sprintf("%s/%s-%s.tgz", tmp, c.Name, c.Version))
+	matches, err := filepath.Glob(fmt.Sprintf("%s/%s-*%s.tgz", tmp, c.Name, c.Version))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/helm/chartCollection.go
+++ b/pkg/helm/chartCollection.go
@@ -88,7 +88,11 @@ func (collection ChartCollection) SetupHelm(setters ...Option) (ChartCollection,
 
 		for _, v := range vs {
 			c := c
-			c.Version = v
+			if strings.HasPrefix(c.Version, "v") {
+				c.Version = "v" + v
+			} else {
+				c.Version = v
+			}
 			res = append(res, c)
 		}
 	}


### PR DESCRIPTION
Fixed bug related to running Helmper against cert-manager Helm Chart.

Helmper now supports specifying semver compliant versions with "v" prefix