### PR TITLE
[fix] value substitution for dependency charts

### DIFF
--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -845,6 +845,18 @@ func (c Chart) Values() (map[string]any, error) {
 		return nil, err
 	}
 
+	if c.Parent != nil {
+		pv, err := c.Parent.Values()
+		if err != nil {
+			return nil, err
+		}
+
+		vs, err = chartutil.CoalesceValues(chartRef, pv[c.Name].(map[string]interface{}))
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return vs.AsMap(), nil
 }
 


### PR DESCRIPTION
Fix Chart value substitution when parsing dependencies