### PR TITLE
[fix] handle copa error when there are no patchable vulnerabilities

### DIFF
--- a/pkg/copa/main.go
+++ b/pkg/copa/main.go
@@ -70,7 +70,7 @@ func (o PatchOption) Run(ctx context.Context, reportFilePaths map[*registry.Imag
 			CertPath:   o.Buildkit.CertPath,
 			KeyPath:    o.Buildkit.KeyPath,
 		}, outFilePaths[i]); err != nil {
-			return err
+			return fmt.Errorf("error patching image %s :: %w ", ref, err)
 		}
 
 		_ = bar.Add(1)

--- a/pkg/helm/chartImportOption.go
+++ b/pkg/helm/chartImportOption.go
@@ -114,7 +114,7 @@ func (opt ChartImportOption) Run(ctx context.Context, setters ...Option) error {
 		}
 
 		for _, r := range opt.Registries {
-
+			registryURL := "oci://" + r.URL + "/charts"
 			if !opt.All {
 				_, err := r.Exist(ctx, "charts/"+c.Name, c.Version)
 				if err == nil {
@@ -125,18 +125,18 @@ func (opt ChartImportOption) Run(ctx context.Context, setters ...Option) error {
 			}
 
 			if opt.ModifyRegistry {
-				res, err := c.PushAndModify("oci://"+r.URL+"/charts", r.Insecure, r.PlainHTTP)
+				res, err := c.PushAndModify(registryURL, r.Insecure, r.PlainHTTP)
 				if err != nil {
-					return err
+					return fmt.Errorf("helm: error pushing and modifying chart %s to registry %s :: %w", c.Name, registryURL, err)
 				}
 				slog.Debug(res)
 
 				continue
 			}
 
-			res, err := c.Push("oci://"+r.URL+"/charts", r.Insecure, r.PlainHTTP)
+			res, err := c.Push(registryURL, r.Insecure, r.PlainHTTP)
 			if err != nil {
-				return err
+				return fmt.Errorf("helm: error pushing chart %s to registry %s :: %w", c.Name, registryURL, err)
 			}
 			slog.Debug(res)
 


### PR DESCRIPTION
Copa returns an error if there are no patchable vulnerabilities. This PR handles that error state to stop Helmper from exiting in the middle of a run. Tested with cert-manager cjart v1.15.0 where the patch was failing with the following error:
```json
{"time":"2024-08-21T12:10:15.893513865Z","level":"ERROR","msg":"no patchable vulnerabilities found"}
```

Additionally, error logging has been improved to add context and an env var config to enable debug logging has been added.