### PR TITLE
[fix] missing default version in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Helmper connects via gRPC to Trivy and Buildkit so you can run `helmper` without
 Simply tell `helmper` which charts to analyze and registries to use by creating a `helmper.yaml` file and run helmper from the same folder.
 
 ```yaml
-k8s_version: 1.27.9
+k8s_version: 1.27.16
 import:
   enabled: true
 charts:
@@ -99,7 +99,7 @@ az acr login -n myregistry
 In this example Helmper will also scan with Trivy, patch with Copacetic and sign with Cosign all identified images before pushing with Oras to all registries.
 
 ```yaml
-k8s_version: 1.27.9
+k8s_version: 1.27.16
 charts:
 - name: prometheus
   version: 25.8.0

--- a/example/helmper.yaml
+++ b/example/helmper.yaml
@@ -1,4 +1,4 @@
-k8s_version: 1.27.9
+k8s_version: 1.27.16
 verbose: true
 update: false
 all: false

--- a/internal/bootstrap/helm.go
+++ b/internal/bootstrap/helm.go
@@ -11,7 +11,7 @@ func SetupHelm(charts *helm.ChartCollection, setters ...helm.Option) (helm.Chart
 	args := &helm.Options{
 		Verbose:    false,
 		Update:     false,
-		K8SVersion: "1.27.7",
+		K8SVersion: "1.27.16",
 	}
 
 	for _, setter := range setters {

--- a/internal/bootstrap/viper.go
+++ b/internal/bootstrap/viper.go
@@ -114,6 +114,7 @@ func LoadViperConfiguration(_ []string) (*viper.Viper, error) {
 	viper.SetDefault("all", false)
 	viper.SetDefault("verbose", false)
 	viper.SetDefault("update", false)
+	viper.SetDefault("k8s_version", "1.27.16")
 
 	// Unmarshal charts config section
 	inputConf := helm.ChartCollection{}

--- a/pkg/helm/chartImportOption.go
+++ b/pkg/helm/chartImportOption.go
@@ -27,7 +27,7 @@ func (opt ChartImportOption) Run(ctx context.Context, setters ...Option) error {
 	args := &Options{
 		Verbose:    false,
 		Update:     false,
-		K8SVersion: "1.27.7",
+		K8SVersion: "1.27.16",
 	}
 
 	for _, setter := range setters {

--- a/pkg/helm/chartOption.go
+++ b/pkg/helm/chartOption.go
@@ -166,7 +166,7 @@ func (co ChartOption) Run(ctx context.Context, setters ...Option) (ChartData, er
 	args := &Options{
 		Verbose:    false,
 		Update:     false,
-		K8SVersion: "1.27.7",
+		K8SVersion: "1.27.16",
 	}
 
 	for _, setter := range setters {

--- a/website/docs/ci.md
+++ b/website/docs/ci.md
@@ -45,7 +45,7 @@ steps:
     targetType: 'inline'
     script: |
       cat <<EOF >>helmper.config
-      k8s_version: 1.27.9
+      k8s_version: 1.27.16
       import:
         enabled: true
       charts:

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -20,7 +20,7 @@ Helmper supports a single flag `--f` to specify the configuration file. When usi
 ## Example configuration
 
 ```yaml title="Example config"
-k8s_version: 1.27.9
+k8s_version: 1.27.16
 verbose: true
 update: false
 all: false
@@ -117,7 +117,7 @@ registries:
 
 | Key | Type  | Default | Required | Description |
 |-|-|-|-|-|
-| `k8s_version` | string       | "1.27.9" | false | Some charts use images eliciting their tag based on the kube-apiserver version. Therefore, tell Helmper which version you run to import the correct version. |
+| `k8s_version` | string       | "1.27.16" | false | Some charts use images eliciting their tag based on the kube-apiserver version. Therefore, tell Helmper which version you run to import the correct version. |
 | `verbose`     | bool         | false    |  false | Toggle verbose output |
 | `update`      | bool         | false    |  false | Toggle update to latest chart version for each specified chart in `charts` |
 | `all`         | bool         | false    |  false | Toggle import of all images regardless if they exist in the registries defined in `registries` |

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -35,7 +35,7 @@ sudo mv helmper-linux-amd64 /usr/local/bin/helmper
 Create the configuration file
 
 ```yaml title="$HOME/.config/helmper/helmper.yaml"
-k8s_version: 1.27.9
+k8s_version: 1.27.16
 import:
   enabled: true
 charts:

--- a/website/docs/intro_extended.md
+++ b/website/docs/intro_extended.md
@@ -65,7 +65,7 @@ Remember to change the user
 :::
 
 ```yaml title="$HOME/.config/helmper/helmper.yaml"
-k8s_version: 1.27.9
+k8s_version: 1.27.16
 charts:
 - name: prometheus
   version: 25.8.0


### PR DESCRIPTION
Fix bug where default k8s version is not set. 
Updated default version to latest patch.

Closes #89