### PR TITLE
[fix] add logic to handle version prefixed with v

### DIFF
--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -424,7 +424,7 @@ func (c Chart) pullTar() (string, error) {
 			return "", err
 		}
 
-		return fmt.Sprintf("%s/%s-%s.tgz", helmCacheHome, c.Name, v), nil
+		return fmt.Sprintf("%s/%s-%s.tgz", helmCacheHome, c.Name, c.Version), nil
 
 	}
 

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -365,9 +365,18 @@ func (c Chart) pullTar() (string, error) {
 
 		ref := strings.TrimSuffix(c.Repo.URL, "/") + "/" + c.Name
 
+		version, vPrefix := strings.CutPrefix(c.Version, "v")
+		if vPrefix {
+			c.Version = version
+		}
+
 		v, err := c.ResolveVersion()
 		if err != nil {
 			return "", err
+		}
+
+		if vPrefix {
+			c.Version = "v" + v
 		}
 
 		co := action.ChartPathOptions{
@@ -378,7 +387,7 @@ func (c Chart) pullTar() (string, error) {
 			PassCredentialsAll:    c.Repo.PassCredentialsAll,
 			Username:              c.Repo.Username,
 			Password:              c.Repo.Password,
-			Version:               v,
+			Version:               c.Version,
 		}
 
 		// You can pass an empty string instead of settings.Namespace() to list


### PR DESCRIPTION
Fix problem with semantic version parsing for Helm charts from OCI registries