### PR TITLE
Fix copacetic error handling when no vulnerabilities found

### DIFF
--- a/pkg/copa/main.go
+++ b/pkg/copa/main.go
@@ -70,7 +70,7 @@ func (o PatchOption) Run(ctx context.Context, reportFilePaths map[*registry.Imag
 			CertPath:   o.Buildkit.CertPath,
 			KeyPath:    o.Buildkit.KeyPath,
 		}, outFilePaths[i]); err != nil {
-			return fmt.Errorf("error patching image %s :: %w ", ref, err)
+			return fmt.Errorf("error patching image %s :: %w", ref, err)
 		}
 
 		_ = bar.Add(1)

--- a/pkg/copa/patch.go
+++ b/pkg/copa/patch.go
@@ -58,7 +58,7 @@ func Patch(ctx context.Context, timeout time.Duration, image, reportFile, patche
 
 	select {
 	case err := <-ch:
-		if err == nil {
+		if err == nil || err.String() == "no patchable vulnerabilities found" {
 			return nil
 		}
 		return fmt.Errorf("copa: error patching image :: %w", err)


### PR DESCRIPTION
Copacetic throws an error upon finding no vulnerabilities. Helmper should not treat that as an error instead it should proceed with the code execution and handle it at code level. There is no type or anything else that can make this solution more elegant, instead we have to resort to string comparison.

Copacetic code causing this issue:
https://github.com/project-copacetic/copacetic/blob/973c6d2909aaa0b6040a0ba2fe57ce02e080ea70/pkg/pkgmgr/pkgmgr.go#L52