### PR TITLE
[feat] add version template for the modify config option

### DIFF
--- a/internal/program.go
+++ b/internal/program.go
@@ -127,7 +127,6 @@ func Program(args []string) error {
 				}
 				for _, modify := range c.Images.Modify {
 					if modify.From != "" {
-
 						if strings.HasPrefix(r, modify.From) {
 							delete(m, i)
 

--- a/pkg/copa/main.go
+++ b/pkg/copa/main.go
@@ -70,7 +70,7 @@ func (o PatchOption) Run(ctx context.Context, reportFilePaths map[*registry.Imag
 			CertPath:   o.Buildkit.CertPath,
 			KeyPath:    o.Buildkit.KeyPath,
 		}, outFilePaths[i]); err != nil {
-			return fmt.Errorf("error patching image %s :: %w ", ref, err)
+			return fmt.Errorf("error patching image %s :: %w", ref, err)
 		}
 
 		_ = bar.Add(1)

--- a/pkg/helm/chartOption.go
+++ b/pkg/helm/chartOption.go
@@ -288,7 +288,11 @@ func (co ChartOption) Run(ctx context.Context, setters ...Option) (ChartData, er
 					for _, mod := range c.Images.Modify {
 						if mod.FromValuePath != "" {
 							slog.Info("modifying chart value", slog.String("HelmValuesPath", mod.FromValuePath), slog.String("new", mod.To))
-							err := replaceValue(strings.Split(mod.FromValuePath, "."), mod.To, chart.Values)
+
+							to := mod.To
+							versionToken := "{.version}"
+							to = strings.Replace(to, versionToken, c.Version, 1)
+							err := replaceValue(strings.Split(mod.FromValuePath, "."), to, chart.Values)
 							if err != nil {
 								return err
 							}


### PR DESCRIPTION
Add option to define a version based on a template, to dynamically use the chart version as part of the replace value

```
...
- name: chartname
  version: "1.2.3"
  repo:
    name: chartrepo
    url: https://raw.githubusercontent.com/"
  images:
    modify:
    - fromValuePath: image.repository
      to: "reg.io/repo/name"
    - fromValuePath: image.tag
      to: "v{.version}"
...
```

Becomes "reg.io/repo/name:v1.2.3"
