### PR TITLE
[bug] add compatability check for charts pushed with last version of helmper

### DIFF
--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -26,6 +26,15 @@ import (
 )
 
 func DependencyToChart(d *chart.Dependency, p *Chart) *Chart {
+	// Backwards compatibility with Charts pushed with helmper 0.1.x
+	if strings.HasPrefix(d.Repository, "oci://") {
+		if !strings.HasSuffix(d.Repository, d.Name) {
+			if strings.HasSuffix(d.Repository, "/charts") {
+				d.Repository = d.Repository + "/" + d.Name
+			}
+		}
+	}
+
 	return &Chart{
 		Name: d.Name,
 		Repo: repo.Entry{


### PR DESCRIPTION
Restore old version related functions for OCI registries
Add compatibility functionality to charts pushed with helmper 0.1.x