### PR TITLE
fix: clone Chart struct when handling semver ranges

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/enescakir/emoji v1.0.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/jedib0t/go-pretty/v6 v6.6.0
+	github.com/jinzhu/copier v0.4.0
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/moby/buildkit v0.15.1
 	github.com/project-copacetic/copacetic v0.7.1-0.20240723231147-beb8c86673a8

--- a/go.sum
+++ b/go.sum
@@ -1014,6 +1014,8 @@ github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267 h1:TMtDYDHKYY
 github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267/go.mod h1:h1nSAbGFqGVzn6Jyl1R/iCcBUHN4g+gW1u9CoBTrb9E=
 github.com/jellydator/ttlcache/v3 v3.3.0 h1:BdoC9cE81qXfrxeb9eoJi9dWrdhSuwXMAnHTbnBm4Wc=
 github.com/jellydator/ttlcache/v3 v3.3.0/go.mod h1:bj2/e0l4jRnQdrnSTaGTsh4GSXvMjQcy41i7th0GVGw=
+github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
+github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jinzhu/gorm v0.0.0-20170222002820-5409931a1bb8 h1:CZkYfurY6KGhVtlalI4QwQ6T0Cu6iuY3e0x5RLu96WE=
 github.com/jinzhu/gorm v0.0.0-20170222002820-5409931a1bb8/go.mod h1:Vla75njaFJ8clLU1W44h34PjIkijhjHIYnZxMqCdxqo=
 github.com/jinzhu/inflection v0.0.0-20170102125226-1c35d901db3d h1:jRQLvyVGL+iVtDElaEIDdKwpPqUIZJfzkNLV34htpEc=

--- a/pkg/helm/chartCollection.go
+++ b/pkg/helm/chartCollection.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/ChristofferNissen/helmper/pkg/util/terminal"
+	"github.com/jinzhu/copier"
 	"helm.sh/helm/v3/pkg/cli"
 )
 
@@ -83,9 +84,13 @@ func (collection ChartCollection) SetupHelm(settings *cli.EnvSettings, setters .
 		}
 
 		for _, v := range vs {
-			c := c
-			c.Version = v
-			res = append(res, c)
+			cv := &Chart{}
+			err := copier.Copy(&cv, &c)
+			if err != nil {
+				return nil, err
+			}
+			cv.Version = v
+			res = append(res, cv)
 		}
 	}
 	collection.Charts = res


### PR DESCRIPTION
It seems the duplicate/copy/clone of the `Chart` struct made for each version matching the semver range is actually the same `Chart` struct. Each matching version overwrites the version field and adds the same struct to the collection.

Output with change:
```
 100% [===============] (3/3) Parsing charts...          
+-------------------------------------------------------------------------------------------------------------+
| Charts                                                                                                      |
+---+-------+--------+---------+----------------+--------+---------+----------+---------+-----------+---------+
| # | TYPE  | CHART  | VERSION | LATEST VERSION | LATEST | VALUES  | SUBCHART | VERSION | CONDITION | ENABLED |
+---+-------+--------+---------+----------------+--------+---------+----------+---------+-----------+---------+
| 0 | Chart | cilium | 1.16.6  | 1.17.1         | ❌     | default |          |         |           |         |
| 1 | Chart | cilium | 1.16.5  | 1.17.1         | ❌     | default |          |         |           |         |
| 2 | Chart | cilium | 1.16.4  | 1.17.1         | ❌     | default |          |         |           |         |
+---+-------+--------+---------+----------------+--------+---------+----------+---------+-----------+---------+
+-------------------------------------------------------+
| Registry Overview For Charts                          |
+---+---------------+---------------+----------+--------+
| # | HELM CHART    | CHART VERSION | REGISTRY | IMPORT |
+---+---------------+---------------+----------+--------+
| 0 | charts/cilium | 1.16.6        | ❌       | ✅     |
| 1 | charts/cilium | 1.16.5        | ❌       | ✅     |
| 2 | charts/cilium | 1.16.4        | ❌       | ✅     |
+---+---------------+---------------+----------+--------+
|   |               |               |          | 3      |
+---+---------------+---------------+----------+--------+
 100% [===============] (3/3) Pushing charts... 
```

Did a d/l of the 3 charts from the registry uploaded by helmper and indeed all 3 charts matching the semver range are as expected.

fixes #152 