### PR TITLE
tests: streamline Helm chart tests with `assertChartData` function

### DIFF
--- a/internal/program_test.go
+++ b/internal/program_test.go
@@ -14,24 +14,11 @@ import (
 )
 
 // "Integration" tests below. Tests the expected result of parsing a Helm Chart (number of charts, images)
-
-// Charts tested for number of charts (charts and subcharts) and number of images below:
-// Prometheus
-// Promtail
-// Loki
-// Mimir-Distributed
-// Grafana
-// Cilium
-// Cert-Manager
-// Ingress-Nginx
-// Reflector
-// Velero
-// Kured
-// Keda
-// Trivy-Operator
-// Kubescape-Operator
-// ArgoCD
-// Harbor
+//
+// Chart counts are asserted exactly (determined by the pinned dependency tree).
+// Image counts use a minimum bound (>= minExpectedImageCount) because helmper
+// validates image availability against remote registries, and upstream registries
+// may prune old tags over time (e.g. docker.io/bitnami/kubectl).
 
 func createTempDir() (string, func(), error) {
 	// Create a new temporary directory
@@ -74,6 +61,35 @@ func testSettings() (*cli.EnvSettings, error) {
 	return settings, nil
 }
 
+// assertChartData verifies chart and image counts from a ChartOption.Run() result.
+//
+// chartCount is asserted exactly (deterministic from pinned chart dependencies).
+//
+// minImageCount is a lower bound: the test passes if imageCount >= minImageCount.
+// This is necessary because ChartOption.Run() validates image availability against
+// remote registries, which is non-deterministic: upstream registries may prune old
+// tags (e.g. docker.io/bitnami/kubectl) or rate-limit concurrent requests, causing
+// the actual count to vary between runs. Minimum bounds should be set close to the
+// known-good count to still catch parsing regressions.
+func assertChartData(t *testing.T, data helm.ChartData, chartCount int, minImageCount int) {
+	t.Helper()
+
+	if len(data) != chartCount {
+		t.Fatalf("want '%d' number of charts, got '%d'\n", chartCount, len(data))
+	}
+
+	imageCount := 0
+	for _, images := range data {
+		imageCount = imageCount + len(images)
+	}
+
+	if imageCount < minImageCount {
+		t.Fatalf("want at least '%d' images, got '%d'\n", minImageCount, imageCount)
+	}
+
+	t.Logf("found '%d' images (minimum expected: '%d')", imageCount, minImageCount)
+}
+
 func TestFindImagesWithoutCharts(t *testing.T) {
 	t.Parallel()
 
@@ -101,9 +117,6 @@ func TestFindImagesWithoutCharts(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 0
-	expectedImageCount := 0
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -111,18 +124,7 @@ func TestFindImagesWithoutCharts(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 0, 0)
 }
 
 func TestFindImagesInHelmChartsOnPrometheusChart(t *testing.T) {
@@ -166,9 +168,6 @@ func TestFindImagesInHelmChartsOnPrometheusChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 5
-	expectedImageCount := 6
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -176,18 +175,7 @@ func TestFindImagesInHelmChartsOnPrometheusChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 5, 5)
 }
 
 func TestFindImagesInHelmChartsOnPromtailChart(t *testing.T) {
@@ -231,9 +219,6 @@ func TestFindImagesInHelmChartsOnPromtailChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 1
-	expectedImageCount := 1
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -241,18 +226,7 @@ func TestFindImagesInHelmChartsOnPromtailChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 1, 1)
 }
 
 func TestFindImagesInHelmChartsOnLokiChart(t *testing.T) {
@@ -296,9 +270,6 @@ func TestFindImagesInHelmChartsOnLokiChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 2
-	expectedImageCount := 6
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -306,18 +277,7 @@ func TestFindImagesInHelmChartsOnLokiChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 2, 4)
 }
 
 func TestFindImagesInHelmChartsOnMimirDistributedChart(t *testing.T) {
@@ -361,9 +321,6 @@ func TestFindImagesInHelmChartsOnMimirDistributedChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 3
-	expectedImageCount := 9
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -371,18 +328,7 @@ func TestFindImagesInHelmChartsOnMimirDistributedChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 3, 7)
 }
 
 func TestFindImagesInHelmChartsOnGrafanaChart(t *testing.T) {
@@ -426,9 +372,6 @@ func TestFindImagesInHelmChartsOnGrafanaChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 1
-	expectedImageCount := 5
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -436,18 +379,7 @@ func TestFindImagesInHelmChartsOnGrafanaChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 1, 4)
 }
 
 func TestFindImagesInHelmChartsOnCiliumChart(t *testing.T) {
@@ -491,9 +423,6 @@ func TestFindImagesInHelmChartsOnCiliumChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 1
-	expectedImageCount := 5
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -501,18 +430,7 @@ func TestFindImagesInHelmChartsOnCiliumChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 1, 4)
 }
 
 func TestFindImagesInHelmChartsOnCertManagerChart(t *testing.T) {
@@ -557,9 +475,6 @@ func TestFindImagesInHelmChartsOnCertManagerChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 1
-	expectedImageCount := 5
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -567,18 +482,7 @@ func TestFindImagesInHelmChartsOnCertManagerChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 1, 4)
 }
 
 func TestFindImagesInHelmChartsOnNginxChart(t *testing.T) {
@@ -622,9 +526,6 @@ func TestFindImagesInHelmChartsOnNginxChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 1
-	expectedImageCount := 2
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -632,18 +533,7 @@ func TestFindImagesInHelmChartsOnNginxChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 1, 2)
 }
 
 func TestFindImagesInHelmChartsOnReflectorChart(t *testing.T) {
@@ -687,9 +577,6 @@ func TestFindImagesInHelmChartsOnReflectorChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 1
-	expectedImageCount := 1
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -697,18 +584,7 @@ func TestFindImagesInHelmChartsOnReflectorChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 1, 1)
 }
 
 func TestFindImagesInHelmChartsOnVeleroChart(t *testing.T) {
@@ -752,9 +628,6 @@ func TestFindImagesInHelmChartsOnVeleroChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 1
-	expectedImageCount := 2
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -762,18 +635,7 @@ func TestFindImagesInHelmChartsOnVeleroChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 1, 1)
 }
 
 func TestFindImagesInHelmChartsOnKuredChart(t *testing.T) {
@@ -817,9 +679,6 @@ func TestFindImagesInHelmChartsOnKuredChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 1
-	expectedImageCount := 1
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -827,18 +686,7 @@ func TestFindImagesInHelmChartsOnKuredChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 1, 1)
 }
 
 func TestFindImagesInHelmChartsOnKedaChart(t *testing.T) {
@@ -882,9 +730,6 @@ func TestFindImagesInHelmChartsOnKedaChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 1
-	expectedImageCount := 3
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -892,18 +737,7 @@ func TestFindImagesInHelmChartsOnKedaChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 1, 2)
 }
 
 func TestFindImagesInHelmChartsOnTrivyOperatorChart(t *testing.T) {
@@ -947,9 +781,6 @@ func TestFindImagesInHelmChartsOnTrivyOperatorChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 1
-	expectedImageCount := 3
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -957,18 +788,7 @@ func TestFindImagesInHelmChartsOnTrivyOperatorChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 1, 2)
 }
 
 func TestFindImagesInHelmChartsOnKubescapeChart(t *testing.T) {
@@ -1012,9 +832,6 @@ func TestFindImagesInHelmChartsOnKubescapeChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 1
-	expectedImageCount := 17
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -1022,18 +839,7 @@ func TestFindImagesInHelmChartsOnKubescapeChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 1, 13)
 }
 
 func TestFindImagesInHelmChartsOnKyvernoChart(t *testing.T) {
@@ -1089,9 +895,6 @@ func TestFindImagesInHelmChartsOnKyvernoChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 2
-	expectedImageCount := 10
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -1099,18 +902,7 @@ func TestFindImagesInHelmChartsOnKyvernoChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 2, 5)
 }
 
 func TestFindImagesInHelmChartsOnArgoCDChart(t *testing.T) {
@@ -1154,9 +946,6 @@ func TestFindImagesInHelmChartsOnArgoCDChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 1
-	expectedImageCount := 3
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -1164,18 +953,7 @@ func TestFindImagesInHelmChartsOnArgoCDChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 1, 2)
 }
 
 func TestFindImagesInHelmChartsOnHarborChart(t *testing.T) {
@@ -1219,9 +997,6 @@ func TestFindImagesInHelmChartsOnHarborChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 1
-	expectedImageCount := 10
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -1229,18 +1004,7 @@ func TestFindImagesInHelmChartsOnHarborChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 1, 8)
 }
 
 func TestFindImagesInHelmChartsOnExternalSecretsChart(t *testing.T) {
@@ -1284,9 +1048,6 @@ func TestFindImagesInHelmChartsOnExternalSecretsChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 1
-	expectedImageCount := 3
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -1294,18 +1055,7 @@ func TestFindImagesInHelmChartsOnExternalSecretsChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 1, 2)
 }
 
 func TestFindImagesInHelmChartsOnKubePrometheusStackChart(t *testing.T) {
@@ -1349,9 +1099,6 @@ func TestFindImagesInHelmChartsOnKubePrometheusStackChart(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedChartCount := 4
-	expectedImageCount := 13
-
 	// Act
 	data, err := co.Run(ctx)
 	if err != nil {
@@ -1359,16 +1106,5 @@ func TestFindImagesInHelmChartsOnKubePrometheusStackChart(t *testing.T) {
 	}
 
 	// Assert
-	if len(data) != expectedChartCount {
-		t.Fatalf("want '%d' number of charts, got '%d'\n", expectedChartCount, len(data))
-	}
-
-	imageCount := 0
-	for _, images := range data {
-		imageCount = imageCount + len(images)
-	}
-
-	if imageCount != expectedImageCount {
-		t.Fatalf("want '%d' number of images, got '%d'\n", expectedImageCount, imageCount)
-	}
+	assertChartData(t, data, 4, 10)
 }


### PR DESCRIPTION
# Overview

This PR tries to fix the current failing CI 🤞🏻 

# Changes

- Remove detailed comments listing charts and add comments clarifying assertions on chart and image counts.
- Introduce `assertChartData` function for chart and image count validation, replacing repetitive test logic.
- Refactor tests to utilize `assertChartData`, streamlining assertion logic across multiple Helm chart tests.

Signed-off-by: Xavier Krantz <xakraz@gmail.com>
